### PR TITLE
Add some small improvements

### DIFF
--- a/css/demo.css
+++ b/css/demo.css
@@ -49,6 +49,7 @@ h2 {
 }
 
 .meny {
+	z-index: 1;
 	display: none;
 	padding: 20px;
 	overflow: auto;
@@ -163,5 +164,3 @@ h2 {
 		position: absolute;
 		bottom: 20px;
 	}
-
-

--- a/js/meny.js
+++ b/js/meny.js
@@ -347,7 +347,6 @@ var Meny = {
 
 					Meny.addClass( dom.wrapper, 'meny-active' );
 
-					dom.cover.style.height = dom.contents.scrollHeight + 'px';
 					dom.cover.style.visibility = 'visible';
 
 					// Use transforms and transitions if available...

--- a/js/meny.js
+++ b/js/meny.js
@@ -278,7 +278,6 @@ var Meny = {
 
 				style.position = 'fixed';
 				style.display = 'block';
-				style.zIndex = 1;
 
 				if( supports3DTransforms ) {
 					style[ Meny.prefix( 'transform' ) ] = menuTransformClosed;


### PR DESCRIPTION
- Move z-index setting from js code to css. Previously it could cause some glitches when you had swipe-able content containing elements with higher z-index. So now you can manually set it higher.
- Fix cover glitch on window re-sizing. (Note: Cover's height is already set to 100% at that line. I think it is much better than a constant value, because it does not cause any glitches.)

Hope you will find my small improvements usefull and I also hope you will merge them!