### PR TITLE
add a mechanism to locate the cover div

### DIFF
--- a/js/meny.js
+++ b/js/meny.js
@@ -215,6 +215,7 @@ var Meny = {
 				}
 
 				dom.cover = document.createElement( 'div' );
+				Meny.addClass(dom.cover, 'meny-cover');
 
 				// Disabled until a falback fade in animation is added
 				dom.cover.style.position = 'absolute';


### PR DESCRIPTION
if you want to be able to implement "click anywhere outside the menu
to close it" functionality, you need to attach a click handler to the
cover div.  rather than play games walking the wrapper children, let's
just give it a class to select.